### PR TITLE
/users のページも GitHub 認証が無いと閲覧できないように変更

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,7 +53,7 @@ app.use(passport.initialize());
 app.use(passport.session());
 
 app.use('/', indexRouter);
-app.use('/users', usersRouter);
+app.use('/users', ensureAuthenticated, usersRouter);
 app.use('/photos', photosRouter);
 
 app.get('/auth/github',
@@ -91,5 +91,12 @@ app.use(function (err, req, res, next) {
   res.status(err.status || 500);
   res.render('error');
 });
+
+function ensureAuthenticated(req, res, next) {
+  if (req.isAuthenticated()) {
+    return next()
+  }
+  res.redirect('/login');
+}
 
 module.exports = app;


### PR DESCRIPTION
ログインしていない状態で /users のページを開こうとすると、ログイン画面にリダイレクトされるようにしました。

※プルリクの練習なのでマージは不要です。