### PR TITLE
/users のページを、認証未完了だと見れないように修正・認証されていない場合 /login にリダイレクトするように設定

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,7 +53,7 @@ app.use(passport.initialize());
 app.use(passport.session());
 
 app.use('/', indexRouter);
-app.use('/users', usersRouter);
+app.use('/users', ensureAuthenticated, usersRouter);
 app.use('/photos', photosRouter);
 
 app.get('/auth/github',
@@ -77,6 +77,11 @@ app.get('/logout', function (req, res, next) {
     res.redirect('/');
   });
 });
+
+function ensureAuthenticated(req, res, next) {
+  if (req.isAuthenticated()) {return next(); }
+  res.redirect('/login');
+}
 
 // catch 404 and forward to error handler
 app.use(function (req, res, next) {


### PR DESCRIPTION
練習問題解答のため、マージは不要です。